### PR TITLE
Support registering system Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           - 3.3.0-preview3
           - jruby-9.4.5.0
           - truffleruby-23.1.1
+          - system
         os:
           - ubuntu
           - macos
@@ -49,6 +50,8 @@ jobs:
           - os: windows
             ruby: truffleruby-23.1.1
           # https://github.com/p0deje/rules_ruby/issues/23
+          - mode: bzlmod
+            ruby: system
           - mode: bzlmod
             ruby: 3.0.6
           - mode: bzlmod
@@ -72,6 +75,10 @@ jobs:
             build --announce_rc
             ${{ matrix.mode == 'bzlmod' && 'common --enable_bzlmod' || '' }}
       - run: echo 'RUBY_VERSION = "${{ matrix.ruby }}"' > ruby_version.bzl
+      - if: matrix.ruby == 'system'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0.6'
       - run: bazel test ...
       - run: bazel run lib/gem:add-numbers 2
       - run: bazel run lib/gem:print-version

--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -91,6 +91,7 @@ rb_register_toolchains(<a href="#rb_register_toolchains-name">name</a>, <a href=
 * _(For MRI on Windows)_ Installed using [RubyInstaller](https://rubyinstaller.org).
 * _(For JRuby on any OS)_ Downloaded and installed directly from [official website](https://www.jruby.org).
 * _(For TruffleRuby on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
+* _(For "system") Ruby found on the PATH is used. Please note that builds are not hermetic in this case.
 
 `WORKSPACE`:
 ```bazel
@@ -108,7 +109,7 @@ rb_register_toolchains(
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="rb_register_toolchains-name"></a>name |  base name of resulting repositories, by default "rules_ruby"   |  <code>"rules_ruby"</code> |
-| <a id="rb_register_toolchains-version"></a>version |  a semver version of Matz Ruby Interpreter, or a string like [interpreter type]-[version]   |  <code>None</code> |
+| <a id="rb_register_toolchains-version"></a>version |  a semver version of Matz Ruby Interpreter, or a string like [interpreter type]-[version], or "system"   |  <code>None</code> |
 | <a id="rb_register_toolchains-register"></a>register |  whether to register the resulting toolchains, should be False under bzlmod   |  <code>True</code> |
 | <a id="rb_register_toolchains-kwargs"></a>kwargs |  additional parameters to the downloader for this interpreter type   |  none |
 

--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -94,7 +94,7 @@ rb_register_toolchains(<a href="#rb_register_toolchains-name">name</a>, <a href=
 
 `WORKSPACE`:
 ```bazel
-load("@rules_ruby//ruby:deps.bzl", "rb_download")
+load("@rules_ruby//ruby:deps.bzl", "rb_register_toolchains")
 
 rb_register_toolchains(
     version = "2.7.5"

--- a/ruby/BUILD
+++ b/ruby/BUILD
@@ -26,7 +26,16 @@ bzl_library(
     srcs = ["deps.bzl"],
     deps = [
         "//ruby/private:bundle",
-        "//ruby/private:download",
+        "//ruby/private:toolchain",
+    ],
+)
+
+bzl_library(
+    name = "extensions",
+    srcs = ["extensions.bzl"],
+    deps = [
+        ":deps",
+        "//ruby/private:toolchain",
     ],
 )
 

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -1,7 +1,7 @@
 "Public API for repository rules"
 
 load("//ruby/private:bundle.bzl", _rb_bundle = "rb_bundle")
-load("//ruby/private:download.bzl", _rb_register_toolchains = "rb_register_toolchains")
+load("//ruby/private:toolchain.bzl", _rb_register_toolchains = "rb_register_toolchains")
 
 def rb_bundle(toolchain = "@rules_ruby_dist//:BUILD", **kwargs):
     """

--- a/ruby/extensions.bzl
+++ b/ruby/extensions.bzl
@@ -1,6 +1,6 @@
 "Module extensions used by bzlmod"
 
-load("//ruby/private:download.bzl", "DEFAULT_RUBY_REPOSITORY")
+load("//ruby/private:toolchain.bzl", "DEFAULT_RUBY_REPOSITORY")
 load(":deps.bzl", "rb_bundle", "rb_register_toolchains")
 
 ruby_bundle = tag_class(attrs = {

--- a/ruby/private/BUILD
+++ b/ruby/private/BUILD
@@ -19,18 +19,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "bundle",
-    srcs = ["bundle.bzl"],
-    visibility = ["//ruby:__subpackages__"],
-)
-
-bzl_library(
-    name = "download",
-    srcs = ["download.bzl"],
-    visibility = ["//ruby:__subpackages__"],
-)
-
-bzl_library(
     name = "gem_build",
     srcs = ["gem_build.bzl"],
     visibility = ["//ruby:__subpackages__"],
@@ -58,12 +46,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "providers",
-    srcs = ["providers.bzl"],
-    visibility = ["//ruby:__subpackages__"],
-)
-
-bzl_library(
     name = "test",
     srcs = ["test.bzl"],
     visibility = ["//ruby:__subpackages__"],
@@ -71,4 +53,32 @@ bzl_library(
         ":binary",
         ":library",
     ],
+)
+
+bzl_library(
+    name = "toolchain",
+    srcs = ["toolchain.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+    deps = [
+        ":download",
+        "//ruby/private/toolchain:repository_proxy",
+    ],
+)
+
+bzl_library(
+    name = "bundle",
+    srcs = ["bundle.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+)
+
+bzl_library(
+    name = "download",
+    srcs = ["download.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
+    visibility = ["//ruby:__subpackages__"],
 )

--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -6,6 +6,8 @@ _RUBY_INSTALLER_URL = "https://github.com/oneclick/rubyinstaller2/releases/downl
 def _rb_download_impl(repository_ctx):
     if repository_ctx.attr.version.startswith("jruby"):
         _install_jruby(repository_ctx)
+    elif repository_ctx.attr.version == "system":
+        _symlink_system_ruby(repository_ctx)
     elif repository_ctx.os.name.startswith("windows"):
         _install_via_rubyinstaller(repository_ctx)
     else:
@@ -93,6 +95,12 @@ def _install_via_ruby_build(repository_ctx):
 
     if result.return_code != 0:
         fail("%s\n%s" % (result.stdout, result.stderr))
+
+def _symlink_system_ruby(repository_ctx):
+    ruby = repository_ctx.which("ruby")
+    repository_ctx.symlink(ruby.dirname, "dist/bin")
+    if repository_ctx.os.name.startswith("windows"):
+        repository_ctx.symlink(ruby.dirname.dirname.get_child("lib"), "dist/lib")
 
 rb_download = repository_rule(
     implementation = _rb_download_impl,

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -13,6 +13,7 @@ def rb_register_toolchains(name = DEFAULT_RUBY_REPOSITORY, version = None, regis
     * _(For MRI on Windows)_ Installed using [RubyInstaller](https://rubyinstaller.org).
     * _(For JRuby on any OS)_ Downloaded and installed directly from [official website](https://www.jruby.org).
     * _(For TruffleRuby on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
+    * _(For "system") Ruby found on the PATH is used. Please note that builds are not hermetic in this case.
 
     `WORKSPACE`:
     ```bazel
@@ -25,14 +26,18 @@ def rb_register_toolchains(name = DEFAULT_RUBY_REPOSITORY, version = None, regis
 
     Args:
         name: base name of resulting repositories, by default "rules_ruby"
-        version: a semver version of Matz Ruby Interpreter, or a string like [interpreter type]-[version]
+        version: a semver version of Matz Ruby Interpreter, or a string like [interpreter type]-[version], or "system"
         register: whether to register the resulting toolchains, should be False under bzlmod
         **kwargs: additional parameters to the downloader for this interpreter type
     """
     repo_name = name + "_dist"
     proxy_repo_name = name + "_toolchains"
     if repo_name not in native.existing_rules().values():
-        _rb_download(name = repo_name, version = version, **kwargs)
+        _rb_download(
+            name = repo_name,
+            version = version,
+            **kwargs
+        )
         _rb_toolchain_repository_proxy(
             name = proxy_repo_name,
             toolchain = "@{}//:toolchain".format(repo_name),

--- a/ruby/private/toolchain/BUILD
+++ b/ruby/private/toolchain/BUILD
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "repository_proxy",
+    srcs = ["repository_proxy.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+)

--- a/ruby/private/toolchain/repository_proxy.bzl
+++ b/ruby/private/toolchain/repository_proxy.bzl
@@ -1,0 +1,29 @@
+"Repository rule for proxying registering Ruby interpreters"
+
+def _rb_toolchain_repository_proxy_impl(repository_ctx):
+    repository_ctx.template(
+        "BUILD",
+        repository_ctx.attr._build_tpl,
+        substitutions = {
+            "{name}": repository_ctx.attr.name,
+            "{toolchain}": repository_ctx.attr.toolchain,
+            "{toolchain_type}": repository_ctx.attr.toolchain_type,
+        },
+        executable = False,
+    )
+
+rb_toolchain_repository_proxy = repository_rule(
+    implementation = _rb_toolchain_repository_proxy_impl,
+    attrs = {
+        "toolchain": attr.string(mandatory = True),
+        "toolchain_type": attr.string(mandatory = True),
+        "_build_tpl": attr.label(
+            allow_single_file = True,
+            default = "@rules_ruby//:ruby/private/toolchain/repository_proxy/BUILD.tpl",
+        ),
+    },
+    doc = """
+A proxy repository that contains the toolchain declaration; this indirection
+allows the Ruby toolchain to be downloaded lazily.
+    """,
+)

--- a/ruby/private/toolchain/repository_proxy/BUILD.tpl
+++ b/ruby/private/toolchain/repository_proxy/BUILD.tpl
@@ -1,0 +1,6 @@
+toolchain(
+    name = "{name}",
+    toolchain = "{toolchain}",
+    toolchain_type = "{toolchain_type}",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Allows to avoid downloading/installing Ruby interpreter at the expense of losing hermeticity and no Ruby version check.

```bazel
# WORKSPACE
load("@rules_ruby//ruby:deps.bzl", "rb_register_toolchains")

rb_register_toolchains(
    version = "system",
)
```

@kigster Does it look reasonable for your case of migrating from Bazelruby?