### PR TITLE
refactor: change naming of external repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ ruby.bundle(
     gemfile = "//:Gemfile",
     toolchain = "@ruby//:BUILD",
 )
-use_repo(ruby, "bundle", "rules_ruby_toolchains")
+use_repo(ruby, "bundle", "ruby_toolchains")
 ```
 
 4. Register Ruby toolchains:
 
 ```bazel
 # MODULE.bazel
-register_toolchains("@rules_ruby_toolchains//:all")
+register_toolchains("@ruby_toolchains//:all")
 ```
 
 4. Start defining your library, binary and test targets in `BUILD` files.

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ rb_bundle(
 # MODULE.bazel
 ruby = use_extension("@rules_ruby//ruby:extensions.bzl", "ruby")
 ruby.toolchain(
-    name = "rules_ruby",
+    name = "ruby",
     version = "3.0.6",
     # alternatively, load version from .ruby-version file
     # version_file = "//:.ruby-version",
 )
-use_repo(ruby, "rules_ruby_dist")
+use_repo(ruby, "ruby")
 ```
 
 3. _(Optional)_ Download and install Bundler dependencies:
@@ -67,7 +67,7 @@ ruby.bundle(
     name = "bundle",
     srcs = ["//:Gemfile.lock"],
     gemfile = "//:Gemfile",
-    toolchain = "@rules_ruby_dist//:BUILD",
+    toolchain = "@ruby//:BUILD",
 )
 use_repo(ruby, "bundle", "rules_ruby_toolchains")
 ```

--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -73,7 +73,7 @@ rb_bundle(<a href="#rb_bundle-toolchain">toolchain</a>, <a href="#rb_bundle-kwar
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rb_bundle-toolchain"></a>toolchain |  default Ruby toolchain BUILD   |  <code>"@rules_ruby_dist//:BUILD"</code> |
+| <a id="rb_bundle-toolchain"></a>toolchain |  default Ruby toolchain BUILD   |  <code>"@ruby//:BUILD"</code> |
 | <a id="rb_bundle-kwargs"></a>kwargs |  underlying attrs passed to rb_bundle_rule()   |  none |
 
 

--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -108,7 +108,7 @@ rb_register_toolchains(
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rb_register_toolchains-name"></a>name |  base name of resulting repositories, by default "rules_ruby"   |  <code>"rules_ruby"</code> |
+| <a id="rb_register_toolchains-name"></a>name |  base name of resulting repositories, by default "rules_ruby"   |  <code>"ruby"</code> |
 | <a id="rb_register_toolchains-version"></a>version |  a semver version of MRI, or a string like [interpreter type]-[version], or "system"   |  <code>None</code> |
 | <a id="rb_register_toolchains-version_file"></a>version_file |  .ruby-version or .tool-versions file to read version from   |  <code>None</code> |
 | <a id="rb_register_toolchains-register"></a>register |  whether to register the resulting toolchains, should be False under bzlmod   |  <code>True</code> |

--- a/examples/gem/MODULE.bazel
+++ b/examples/gem/MODULE.bazel
@@ -9,10 +9,10 @@ local_path_override(
 
 ruby = use_extension("@rules_ruby//ruby:extensions.bzl", "ruby")
 ruby.toolchain(
-    name = "rules_ruby",
+    name = "ruby",
     version_file = "//:.ruby-version",
 )
-use_repo(ruby, "rules_ruby_dist")
+use_repo(ruby, "ruby")
 ruby.bundle(
     name = "bundle",
     srcs = [
@@ -24,7 +24,7 @@ ruby.bundle(
         "BUNDLE_BUILD__FOO": "bar",
     },
     gemfile = "//:Gemfile",
-    toolchain = "@rules_ruby_dist//:BUILD",
+    toolchain = "@ruby//:BUILD",
 )
 use_repo(ruby, "bundle", "rules_ruby_toolchains")
 

--- a/examples/gem/MODULE.bazel
+++ b/examples/gem/MODULE.bazel
@@ -26,6 +26,6 @@ ruby.bundle(
     gemfile = "//:Gemfile",
     toolchain = "@ruby//:BUILD",
 )
-use_repo(ruby, "bundle", "rules_ruby_toolchains")
+use_repo(ruby, "bundle", "ruby_toolchains")
 
-register_toolchains("@rules_ruby_toolchains//:all")
+register_toolchains("@ruby_toolchains//:all")

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -3,7 +3,7 @@
 load("//ruby/private:bundle.bzl", _rb_bundle = "rb_bundle")
 load("//ruby/private:toolchain.bzl", _rb_register_toolchains = "rb_register_toolchains")
 
-def rb_bundle(toolchain = "@rules_ruby_dist//:BUILD", **kwargs):
+def rb_bundle(toolchain = "@ruby//:BUILD", **kwargs):
     """
     Wraps `rb_bundle_rule()` providing default toolchain name.
 

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -3,7 +3,7 @@
 load("//ruby/private:download.bzl", _rb_download = "rb_download")
 load("//ruby/private/toolchain:repository_proxy.bzl", _rb_toolchain_repository_proxy = "rb_toolchain_repository_proxy")
 
-DEFAULT_RUBY_REPOSITORY = "rules_ruby"
+DEFAULT_RUBY_REPOSITORY = "ruby"
 
 def rb_register_toolchains(name = DEFAULT_RUBY_REPOSITORY, version = None, version_file = None, register = True, **kwargs):
     """
@@ -31,18 +31,17 @@ def rb_register_toolchains(name = DEFAULT_RUBY_REPOSITORY, version = None, versi
         register: whether to register the resulting toolchains, should be False under bzlmod
         **kwargs: additional parameters to the downloader for this interpreter type
     """
-    repo_name = name + "_dist"
     proxy_repo_name = name + "_toolchains"
-    if repo_name not in native.existing_rules().values():
+    if name not in native.existing_rules().values():
         _rb_download(
-            name = repo_name,
+            name = name,
             version = version,
             version_file = version_file,
             **kwargs
         )
         _rb_toolchain_repository_proxy(
             name = proxy_repo_name,
-            toolchain = "@{}//:toolchain".format(repo_name),
+            toolchain = "@{}//:toolchain".format(name),
             toolchain_type = "@rules_ruby//ruby:toolchain_type",
         )
         if register:


### PR DESCRIPTION
This is based on a couple of observations:
- The "name" provided by the user when calling a repository rule should result in a repository of exactly that name, otherwise there is a magical transformation that you have to track down from some documentation. `make_repo("foo") -> @foo//some:label`
- we already have a repository "rules_ruby" which is the one installed by the user to get this code, so it is confusing to use that name or a similar one for the repository containing the interpreter.

BREAKING CHANGE:
The name of the default generated repository to load the interpreter has changed from `rules_ruby_dist` to `ruby`, or from `[name]_dist` to `[name]` if you provided a different name.