### PR TITLE
feat: update Ruby to 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - 3.0.6
           - 3.1.4
           - 3.2.2
-          - 3.3.0-preview3
+          - 3.3.0
           - jruby-9.4.5.0
           - truffleruby-23.1.1
           - system
@@ -47,9 +47,6 @@ jobs:
           - bzlmod
           - WORKSPACE
         exclude:
-          # RubyInstaller doesn't ship previews.
-          - os: windows
-            ruby: 3.3.0-preview3
           # TruffleRuby doesn't work on Windows.
           - os: windows
             ruby: truffleruby-23.1.1

--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ See [`examples`][14] directory for a comprehensive set of examples how to use th
 
 The following toolchains are known to work and tested on CI.
 
-| Ruby              | Linux | macOS | Windows |
-|-------------------|-------|-------|---------|
-| MRI 3.3 (preview) | 🟩    | 🟩    | 🟥      |
-| MRI 3.2           | 🟩    | 🟩    | 🟩      |
-| MRI 3.1           | 🟩    | 🟩    | 🟩      |
-| MRI 3.0           | 🟩    | 🟩    | 🟩      |
-| JRuby 9.4         | 🟩    | 🟩    | 🟩      |
-| TruffleRuby 23.0  | 🟩    | 🟩    | 🟥      |
+| Ruby             | Linux | macOS | Windows |
+|------------------|-------|-------|---------|
+| MRI 3.3          | 🟩    | 🟩    | 🟩      |
+| MRI 3.2          | 🟩    | 🟩    | 🟩      |
+| MRI 3.1          | 🟩    | 🟩    | 🟩      |
+| MRI 3.0          | 🟩    | 🟩    | 🟩      |
+| JRuby 9.4        | 🟩    | 🟩    | 🟩      |
+| TruffleRuby 23.0 | 🟩    | 🟩    | 🟥      |
 
 The following toolchains were previously known to work but *no longer tested on CI*.
 

--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -137,7 +137,7 @@ rb_download = repository_rule(
             doc = "File to read Ruby version from.",
         ),
         "ruby_build_version": attr.string(
-            default = "20231114",
+            default = "20231225",
             doc = """
 Version of [ruby-build](https://github.com/rbenv/ruby-build/releases)
 to install. You normally don't need to change this, unless `version` you pass is a new one


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/