### PR TITLE
fix: filter runfiles with whitespace in their paths

### DIFF
--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -156,7 +156,7 @@ def rb_binary_impl(ctx):
     env.update(ctx.attr.env)
 
     runfile_srcs = transitive_srcs + transitive_data + tools
-    
+
     # Some gems may have spaces in their paths, which are not supported by runfiles.
     runfile_srcs = [f for f in runfile_srcs if " " not in f.path]
     runfiles = ctx.runfiles(runfile_srcs)

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -156,8 +156,9 @@ def rb_binary_impl(ctx):
     env.update(ctx.attr.env)
 
     runfile_srcs = transitive_srcs + transitive_data + tools
+    
     # Some gems may have spaces in their paths, which are not supported by runfiles.
-    runfile_srcs =  [f for f in runfile_srcs if " " not in f.path]
+    runfile_srcs = [f for f in runfile_srcs if " " not in f.path]
     runfiles = ctx.runfiles(runfile_srcs)
     runfiles = get_transitive_runfiles(runfiles, ctx.attr.srcs, ctx.attr.deps, ctx.attr.data)
 

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -155,7 +155,10 @@ def rb_binary_impl(ctx):
     env.update(ruby_toolchain.env)
     env.update(ctx.attr.env)
 
-    runfiles = ctx.runfiles(transitive_srcs + transitive_data + tools)
+    runfile_srcs = transitive_srcs + transitive_data + tools
+    # Some gems may have spaces in their paths, which are not supported by runfiles.
+    runfile_srcs =  [f for f in runfile_srcs if " " not in f.path]
+    runfiles = ctx.runfiles(runfile_srcs)
     runfiles = get_transitive_runfiles(runfiles, ctx.attr.srcs, ctx.attr.deps, ctx.attr.data)
 
     # Propagate executable from source rb_binary() targets.


### PR DESCRIPTION
Remove runfiles that contain spaces in their filenames, typically seen as gems with poor file naming choices. The `--experimental_inprocess_symlink_creation` flag is recommended to get around the issue noted in bazelbuild/bazel#4327, but that workaround does not seem to work in `bazel build` contexts.
