### PR TITLE
Add `bundler_remote` attribute to `rb_bundle_fetch`

### DIFF
--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -73,7 +73,7 @@ $ bazel run @ruby//:gem -- install rails
 ## rb_bundle_fetch
 
 <pre>
-rb_bundle_fetch(<a href="#rb_bundle_fetch-name">name</a>, <a href="#rb_bundle_fetch-srcs">srcs</a>, <a href="#rb_bundle_fetch-env">env</a>, <a href="#rb_bundle_fetch-gemfile">gemfile</a>, <a href="#rb_bundle_fetch-gemfile_lock">gemfile_lock</a>, <a href="#rb_bundle_fetch-repo_mapping">repo_mapping</a>)
+rb_bundle_fetch(<a href="#rb_bundle_fetch-name">name</a>, <a href="#rb_bundle_fetch-srcs">srcs</a>, <a href="#rb_bundle_fetch-bundler_remote">bundler_remote</a>, <a href="#rb_bundle_fetch-env">env</a>, <a href="#rb_bundle_fetch-gemfile">gemfile</a>, <a href="#rb_bundle_fetch-gemfile_lock">gemfile_lock</a>, <a href="#rb_bundle_fetch-repo_mapping">repo_mapping</a>)
 </pre>
 
 Fetches Bundler dependencies to be automatically installed by other targets.
@@ -119,6 +119,7 @@ rb_test(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rb_bundle_fetch-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="rb_bundle_fetch-srcs"></a>srcs |  List of Ruby source files necessary during installation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="rb_bundle_fetch-bundler_remote"></a>bundler_remote |  Remote to fetch the bundler gem from.   | String | optional |  `"https://rubygems.org/"`  |
 | <a id="rb_bundle_fetch-env"></a>env |  Environment variables to use during installation.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="rb_bundle_fetch-gemfile"></a>gemfile |  Gemfile to install dependencies from.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="rb_bundle_fetch-gemfile_lock"></a>gemfile_lock |  Gemfile.lock to install dependencies from.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |

--- a/ruby/private/bundle_fetch.bzl
+++ b/ruby/private/bundle_fetch.bzl
@@ -102,7 +102,10 @@ def _rb_bundle_fetch_impl(repository_ctx):
         srcs.append(src.name)
         repository_ctx.file(src.name, repository_ctx.read(src))
 
-    gemfile_lock = parse_gemfile_lock(repository_ctx.read(gemfile_lock_path))
+    gemfile_lock = parse_gemfile_lock(
+        repository_ctx.read(gemfile_lock_path),
+        repository_ctx.attr.bundler_remote,
+    )
     if not versions.is_at_least("2.2.19", gemfile_lock.bundler.version):
         fail(_OUTDATED_BUNDLER_ERROR)
 
@@ -197,6 +200,10 @@ rb_bundle_fetch = repository_rule(
         ),
         "env": attr.string_dict(
             doc = "Environment variables to use during installation.",
+        ),
+        "bundler_remote": attr.string(
+            default = "https://rubygems.org/",
+            doc = "Remote to fetch the bundler gem from.",
         ),
         "_build_tpl": attr.label(
             allow_single_file = True,

--- a/ruby/private/bundle_fetch/gemfile_lock_parser.bzl
+++ b/ruby/private/bundle_fetch/gemfile_lock_parser.bzl
@@ -111,7 +111,7 @@ def _parse_git_package(lines):
 
     return {"revision": revision, "remote": remote}
 
-def parse_gemfile_lock(content):
+def parse_gemfile_lock(content, bundler_remote):
     """Parses a Gemfile.lock.
 
     Find lines in the content of a Gemfile.lock that look like package
@@ -119,6 +119,7 @@ def parse_gemfile_lock(content):
 
     Args:
         content: Gemfile.lock contents
+        bundler_remote: Remote URL for the bundler package.
 
     Returns:
         struct with parsed Gemfile.lock
@@ -180,7 +181,7 @@ def parse_gemfile_lock(content):
                 version = version,
                 filename = "bundler-%s.gem" % version,
                 full_name = "bundler-%s" % version,
-                remote = remote,
+                remote = bundler_remote,
             )
             inside_bundled_with = False
 

--- a/ruby/private/bundle_fetch/gemfile_lock_parser.bzl
+++ b/ruby/private/bundle_fetch/gemfile_lock_parser.bzl
@@ -180,7 +180,7 @@ def parse_gemfile_lock(content):
                 version = version,
                 filename = "bundler-%s.gem" % version,
                 full_name = "bundler-%s" % version,
-                remote = "https://rubygems.org/",
+                remote = remote,
             )
             inside_bundled_with = False
 


### PR DESCRIPTION
Our builds don't permit access to `rubygems.org` and this one is easy to fix.