### PR TITLE
feat: allow customizing `$PATH` during `rb_bundle_fetch`

### DIFF
--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -60,7 +60,7 @@ $ bazel run @ruby//:gem -- install rails
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rb_register_toolchains-name"></a>name |  base name of resulting repositories, by default "rules_ruby"   |  `"ruby"` |
+| <a id="rb_register_toolchains-name"></a>name |  base name of resulting repositories, by default "ruby"   |  `"ruby"` |
 | <a id="rb_register_toolchains-version"></a>version |  a semver version of MRI, or a string like [interpreter type]-[version], or "system"   |  `None` |
 | <a id="rb_register_toolchains-version_file"></a>version_file |  .ruby-version or .tool-versions file to read version from   |  `None` |
 | <a id="rb_register_toolchains-msys2_packages"></a>msys2_packages |  extra MSYS2 packages to install   |  `["libyaml"]` |

--- a/ruby/private/bundle_install.bzl
+++ b/ruby/private/bundle_install.bzl
@@ -37,11 +37,13 @@ def _rb_bundle_install_impl(ctx):
     if _is_windows(ctx):
         script = ctx.actions.declare_file("bundle_install_{}.cmd".format(ctx.label.name))
         template = ctx.file._bundle_install_cmd_tpl
-        env.update({"PATH": _normalize_path(ctx, toolchain.ruby.dirname) + ";%PATH%"})
+        path = ctx.attr.env.get("PATH", "%PATH%")
+        env.update({"PATH": _normalize_path(ctx, toolchain.ruby.dirname) + ";" + path})
     else:
         script = ctx.actions.declare_file("bundle_install_{}.sh".format(ctx.label.name))
         template = ctx.file._bundle_install_sh_tpl
-        env.update({"PATH": "%s:$PATH" % toolchain.ruby.dirname})
+        path = ctx.attr.env.get("PATH", "$PATH")
+        env.update({"PATH": toolchain.ruby.dirname + ":" + path})
 
     # Calculate relative location between BUNDLE_GEMFILE and BUNDLE_PATH.
     relative_dir = "../../"

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -39,7 +39,7 @@ def rb_register_toolchains(
     ```
 
     Args:
-        name: base name of resulting repositories, by default "rules_ruby"
+        name: base name of resulting repositories, by default "ruby"
         version: a semver version of MRI, or a string like [interpreter type]-[version], or "system"
         version_file: .ruby-version or .tool-versions file to read version from
         msys2_packages: extra MSYS2 packages to install


### PR DESCRIPTION
Right now, we're overwriting `$PATH` regardless of what the user specifies in `env`. With this change, we use the user's provided value in addition to adding our own entry.

This is necessary for some gems that depend on system binaries. For example, the `pg` gem depends on `pg_config` binary.

Bazel already adds some standard directories like `/usr/local/bin` to `$PATH`. But, that isn't sufficient on recent versions of MacOS because Homebrew stores packages elsewhere (see https://github.com/bazelbuild/bazel/issues/12049).

This change allows users who are comfortable with not fully hermetic bundle builds to opt into it by tweaking `$PATH`.