### PR TITLE
revert: default toolchain is jruby

### DIFF
--- a/examples/gem/.ruby-version
+++ b/examples/gem/.ruby-version
@@ -1,1 +1,1 @@
-truffleruby-24.0.0
+jruby-9.4.6.0


### PR DESCRIPTION
Switching to TruffleRuby was a mis-committed change. Fixes BCR CI from https://github.com/bazelbuild/bazel-central-registry/pull/1664