### PR TITLE
fix: properly locate OS-installed `system` Ruby

### DIFF
--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -230,10 +230,14 @@ def _install_via_ruby_build(repository_ctx, version):
         fail("%s\n%s" % (result.stdout, result.stderr))
 
 def _symlink_system_ruby(repository_ctx):
-    ruby = repository_ctx.which("ruby")
-    repository_ctx.symlink(ruby.dirname, "dist/bin")
+    result = repository_ctx.execute(["ruby", "-e", "puts RbConfig.ruby"])
+    if result.return_code != 0:
+        fail("Failed to determine the system Ruby path:\n%s\n%s" % (result.stdout, result.stderr))
+    ruby_path = result.stdout.strip()
+    ruby_dir = repository_ctx.path(ruby_path).dirname
+    repository_ctx.symlink(ruby_dir, "dist/bin")
     if repository_ctx.os.name.startswith("windows"):
-        repository_ctx.symlink(ruby.dirname.dirname.get_child("lib"), "dist/lib")
+        repository_ctx.symlink(ruby_dir.dirname.get_child("lib"), "dist/lib")
 
 rb_download = repository_rule(
     implementation = _rb_download_impl,


### PR DESCRIPTION
Related to #125

Updates the method for determining the system Ruby path in `ruby/private/download.bzl`.

- Replaces the use of `repository_ctx.which("ruby")` with `repository_ctx.execute(["ruby", "-e", "puts RbConfig.ruby"])` to accurately determine the Ruby binary path when using the system Ruby.
- Implements error handling for the command execution, failing the build with a clear message if the system Ruby path cannot be determined.
- Maintains the symlink creation logic to link the determined Ruby directory to `dist/bin`, ensuring compatibility with existing setups.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bazel-contrib/rules_ruby/issues/125?shareId=82c03088-9c65-4564-af8b-4c7aec83de72).