### PR TITLE
add `--disable-install-doc` to Ruby configure args to speed up installation time

### DIFF
--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -219,7 +219,7 @@ def _install_via_ruby_build(repository_ctx, version):
 
     repository_ctx.report_progress("Installing Ruby %s" % version)
     result = repository_ctx.execute(
-        ["ruby-build/bin/ruby-build", "--verbose", version, "dist"],
+        ["ruby-build/bin/ruby-build", "--verbose", version, "dist", "--", "--disable-install-doc"],
         timeout = 1200,
         quiet = not repository_ctx.os.environ.get("RUBY_RULES_DEBUG", default = False),
     )


### PR DESCRIPTION
👋 I was looking at possible opportunities to speed up Ruby build time and this one seemed like a good candidate. I was able to shave off about 30 seconds by adding this flag to not compile docs material.

On my M3 Max laptop, installing Ruby 3.3.2 with current `main`:
```
0.08s user 0.12s system 0% cpu 1:21.58 total
```

With this change:
```
0.06s user 0.08s system 0% cpu 52.332 total
```

Another more extensible approach could be to make this part of a  configurable `configure` arg setting passed into the rules' toolchain config. But I thought perhaps this is just a good start to add this as a way to speed up the rules fetch in general, and I couldn't really think of a reason someone would want doc generation for the core Ruby itself in the context of a Bazel build.