### PR TITLE
Set `$HOME` to `$TEST_TMPDIR` in test targets

### DIFF
--- a/ruby/private/binary/binary.cmd.tpl
+++ b/ruby/private/binary/binary.cmd.tpl
@@ -14,6 +14,17 @@ if "{java_bin}" neq "" (
   for %%a in ("!java_bin!\..\..") do set JAVA_HOME=%%~fa
 )
 
+:: Bundler expects the %HOME% directory to be writable and produces misleading
+:: warnings if it isn't. This isn't the case in every situation (e.g. remote
+:: execution) and Bazel recommends using %TEST_TMPDIR% when it's available:
+:: https://bazel.build/reference/test-encyclopedia#initial-conditions
+::
+:: We set %HOME% prior to setting environment variables from the target itself
+:: so that users can override this behavior if they desire.
+if defined TEST_TMPDIR (
+  set "HOME=%TEST_TMPDIR%"
+)
+
 :: Set environment variables.
 {env}
 

--- a/ruby/private/binary/binary.sh.tpl
+++ b/ruby/private/binary/binary.sh.tpl
@@ -26,6 +26,17 @@ if [ -n "{java_bin}" ]; then
   export JAVA_HOME=$(dirname $(dirname $(rlocation "{java_bin}")))
 fi
 
+# Bundler expects the $HOME directory to be writable and produces misleading
+# warnings if it isn't. This isn't the case in every situation (e.g. remote
+# execution) and Bazel recommends using $TEST_TMPDIR when it's available:
+# https://bazel.build/reference/test-encyclopedia#initial-conditions
+#
+# We set $HOME prior to setting environment variables from the target itself so
+# that users can override this behavior if they desire.
+if [ -n "${TEST_TMPDIR:-}" ]; then
+  export HOME=$TEST_TMPDIR
+fi
+
 # Set environment variables.
 {env}
 


### PR DESCRIPTION
This eliminates the following warning:

```
`/` is not writable.
Bundler will use `/tmp/bundler20290814-15-18gxxtn15' as your home directory temporarily.
`/` is not writable.
Bundler will use `/tmp/bundler20290814-15-1tue52e15' as your home directory temporarily.
```