### PR TITLE
fix: use override Ruby toolchain consistently

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -191,7 +191,7 @@ used by `rb_bundle_fetch()`.
 ## rb_gem_build
 
 <pre>
-rb_gem_build(<a href="#rb_gem_build-name">name</a>, <a href="#rb_gem_build-deps">deps</a>, <a href="#rb_gem_build-srcs">srcs</a>, <a href="#rb_gem_build-data">data</a>, <a href="#rb_gem_build-bundle_env">bundle_env</a>, <a href="#rb_gem_build-gemspec">gemspec</a>)
+rb_gem_build(<a href="#rb_gem_build-name">name</a>, <a href="#rb_gem_build-deps">deps</a>, <a href="#rb_gem_build-srcs">srcs</a>, <a href="#rb_gem_build-data">data</a>, <a href="#rb_gem_build-bundle_env">bundle_env</a>, <a href="#rb_gem_build-gemspec">gemspec</a>, <a href="#rb_gem_build-ruby">ruby</a>)
 </pre>
 
 Builds a Ruby gem.
@@ -281,6 +281,7 @@ $ bazel build :gem-build
 | <a id="rb_gem_build-data"></a>data |  List of runtime dependencies needed by a program that depends on this library.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="rb_gem_build-bundle_env"></a>bundle_env |  List of bundle environment variables to set when building the library.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="rb_gem_build-gemspec"></a>gemspec |  Gemspec file to use for gem building.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="rb_gem_build-ruby"></a>ruby |  Override Ruby toolchain to use when running the script.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
 <a id="rb_gem_install"></a>

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -138,6 +138,8 @@ def rb_binary_impl(ctx):
     transitive_srcs = get_transitive_srcs(ctx.files.srcs, ctx.attr.deps).to_list()
 
     ruby_toolchain = ctx.toolchains["@rules_ruby//ruby:toolchain_type"]
+    if ctx.attr.ruby != None:
+        ruby_toolchain = ctx.attr.ruby[platform_common.ToolchainInfo]
     tools = [ctx.file._runfiles_library]
     tools.extend(ruby_toolchain.files)
 

--- a/ruby/private/gem_build.bzl
+++ b/ruby/private/gem_build.bzl
@@ -1,5 +1,6 @@
 "Implementation details for rb_gem_build"
 
+load("//ruby/private:binary.bzl", BINARY_ATTRS = "ATTRS")
 load("//ruby/private:library.bzl", LIBRARY_ATTRS = "ATTRS")
 load(
     "//ruby/private:providers.bzl",
@@ -20,6 +21,8 @@ def _rb_gem_build_impl(ctx):
     bundle_env = get_bundle_env({}, ctx.attr.deps)
     java_toolchain = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"]
     ruby_toolchain = ctx.toolchains["@rules_ruby//ruby:toolchain_type"]
+    if ctx.attr.ruby != None:
+        ruby_toolchain = ctx.attr.ruby[platform_common.ToolchainInfo]
     tools = []
     tools.extend(ruby_toolchain.files)
 
@@ -97,6 +100,7 @@ rb_gem_build = rule(
     _rb_gem_build_impl,
     attrs = dict(
         LIBRARY_ATTRS,
+        ruby = BINARY_ATTRS["ruby"],
         gemspec = attr.label(
             allow_single_file = [".gemspec"],
             mandatory = True,

--- a/ruby/private/gem_push.bzl
+++ b/ruby/private/gem_push.bzl
@@ -7,6 +7,8 @@ def _rb_gem_push_impl(ctx):
     env = {}
     java_toolchain = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"]
     ruby_toolchain = ctx.toolchains["@rules_ruby//ruby:toolchain_type"]
+    if ctx.attr.ruby != None:
+        ruby_toolchain = ctx.attr.ruby[platform_common.ToolchainInfo]
     srcs = [ctx.file.gem]
     tools = [ruby_toolchain.gem, ctx.file._runfiles_library]
 


### PR DESCRIPTION
I missed a couple spots where we should be using the override toolchain in https://github.com/bazel-contrib/rules_ruby/pull/140.

This time, I audited all the places we have a `ctx.toolchains["@rules_ruby//ruby:toolchain_type"]` and made sure that we use the override toolchain in them.

Without this change, binary targets like `@bundle//:rubocop` can end up pointing to a Ruby version that isn't actually in the runfiles for the target.