### PR TITLE
chore: return `WORKSPACE` for Bazel 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ This repository hosts [Ruby][1] language ruleset for [Bazel][2].
 
 The ruleset is known to work with:
 
-- Bazel 8 using WORKSPACE and Bzlmod *(tested on CI)*;
-- Bazel 7 using WORKSPACE and Bzlmod *(no longer tested on CI)*;
-- Bazel 6 using WORKSPACE and Bzlmod *(no longer tested on CI)*;
-- Bazel 5 using WORKSPACE *(no longer tested on CI)*.
+- Bazel 8 using WORKSPACE and Bzlmod *(tested on CI)*.
+- Bazel 7 using WORKSPACE and Bzlmod *(no longer tested on CI)*.
+- Bazel 6 using WORKSPACE and Bzlmod *(no longer tested on CI)*.
 
 ## Getting Started
 


### PR DESCRIPTION
This should fix CI failures like https://github.com/bazelbuild/bazel-central-registry/pull/3475