### PR TITLE
feat: expose Ruby engine configuration

### DIFF
--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -58,6 +58,22 @@ $ bazel run @ruby//:bundle -- update
 $ bazel run @ruby//:gem -- install rails
 ```
 
+You can also use Ruby engine targets to `select()` depending on installed Ruby interpreter:
+
+`BUILD`:
+```bazel
+rb_library(
+    name = "my_lib",
+    srcs = ["my_lib.rb"],
+    deps = select({
+        "@ruby//engine:jruby": [":my_jruby_lib"],
+        "@ruby//engine:truffleruby": ["//:my_truffleruby_lib"],
+        "@ruby//engine:ruby": ["//:my__lib"],
+        "//conditions:default": [],
+    }),
+)
+```
+
 
 **PARAMETERS**
 

--- a/examples/gem/spec/BUILD
+++ b/examples/gem/spec/BUILD
@@ -38,7 +38,11 @@ rb_test(
         "LOCATION_SRC": "$(location :env_spec)",
         "LOCATION_DEP": "$(location //lib/gem:add)",
         "LOCATION_DATA": "$(location //spec/support:file)",
-    },
+    } | select({
+        "@ruby//engine:jruby": {"RUBY_ENGINE": "jruby"},
+        "@ruby//engine:truffleruby": {"RUBY_ENGINE": "truffleruby"},
+        "//conditions:default": {"RUBY_ENGINE": "ruby"},
+    }),
     env_inherit = [
         "USER",  # POSIX
         "USERNAME",  # Windows

--- a/examples/gem/spec/env_spec.rb
+++ b/examples/gem/spec/env_spec.rb
@@ -20,4 +20,8 @@ RSpec.describe ENV do
     expect(File).to exist(ENV.fetch('LOCATION_DATA'))
     expect(File).to exist(ENV.fetch('LOCATION_DEP'))
   end
+
+  specify do
+    expect(ENV.fetch('RUBY_ENGINE')).to eq(RUBY_ENGINE)
+  end
 end

--- a/ruby/private/download/BUILD.engine.tpl
+++ b/ruby/private/download/BUILD.engine.tpl
@@ -1,0 +1,36 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+string_flag(
+    name = "engine",
+    values = [
+        "jruby",
+        "truffleruby",
+        "ruby",
+    ],
+    build_setting_default = "{ruby_engine}",
+)
+
+config_setting(
+    name = "jruby",
+    flag_values = {
+        ":engine": "jruby",
+    },
+)
+
+config_setting(
+    name = "truffleruby",
+    flag_values = {
+        ":engine": "truffleruby",
+    },
+)
+
+config_setting(
+    name = "ruby",
+    flag_values = {
+        ":engine": "ruby",
+    },
+)
+
+# vim: ft=bzl

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -38,6 +38,22 @@ def rb_register_toolchains(
     $ bazel run @ruby//:gem -- install rails
     ```
 
+    You can also use Ruby engine targets to `select()` depending on installed Ruby interpreter:
+
+    `BUILD`:
+    ```bazel
+    rb_library(
+        name = "my_lib",
+        srcs = ["my_lib.rb"],
+        deps = select({
+            "@ruby//engine:jruby": [":my_jruby_lib"],
+            "@ruby//engine:truffleruby": ["//:my_truffleruby_lib"],
+            "@ruby//engine:ruby": ["//:my__lib"],
+            "//conditions:default": [],
+        }),
+    )
+    ```
+
     Args:
         name: base name of resulting repositories, by default "ruby"
         version: a semver version of MRI, or a string like [interpreter type]-[version], or "system"


### PR DESCRIPTION
Exposes Ruby engine targets to `select()` depending on installed Ruby interpreter:

`BUILD`:
```bazel
rb_library(
    name = "my_lib",
    srcs = ["my_lib.rb"],
    deps = select({
        "@ruby//engine:jruby": [":my_jruby_lib"],
        "@ruby//engine:truffleruby": ["//:my_truffleruby_lib"],
        "@ruby//engine:ruby": ["//:my__lib"],
        "//conditions:default": [],
    }),
)
```