### PR TITLE
chore(deps): ignore rules_cc and rules_java

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
   ],
   "ignoreDeps": [
     "bazel_skylib",
-    "platforms"
+    "platforms",
+    "rules_cc",
+    "rules_java"
   ]
 }


### PR DESCRIPTION
Direct dependencies should not be updated without a good reason (see MODULE.bazel).