### PR TITLE
fix: include files in rb_binary DefaultInfo

### DIFF
--- a/examples/native_ext/MODULE.bazel
+++ b/examples/native_ext/MODULE.bazel
@@ -1,7 +1,7 @@
 "Bazel dependencies"
 
 bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
-bazel_dep(name = "rules_cc", version = "0.1.0", dev_dependency = True)
+bazel_dep(name = "rules_cc", version = "0.1.1", dev_dependency = True)
 bazel_dep(name = "rules_java", version = "8.7.1", dev_dependency = True)
 bazel_dep(name = "rules_ruby", version = "0.0.0", dev_dependency = True)
 local_path_override(

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -191,6 +191,7 @@ def rb_binary_impl(ctx):
     return [
         DefaultInfo(
             executable = script,
+            files = depset(transitive = [transitive_srcs, depset(tools, transitive = [transitive_data])]),
             runfiles = runfiles,
         ),
         RubyFilesInfo(


### PR DESCRIPTION
run_binary() uses files from DefaultInfo to lay out the tree of dependencies for executable.

This was accidentally broken in 5008f8a8355b4927bc4564c39b109dfe36199994.