### PR TITLE
ci: exclude sh_test from Bazel CI

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -10,5 +10,7 @@ bcr_test_module:
       name: "Run test module"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
+      test_flags:
+        - "--test_tag_filters -bcr-presubmit-failure"
       test_targets:
         - "//..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
           - 3.2.6
           - 3.3.7
           - 3.4.1
-          - jruby-9.4.10.0
-          - truffleruby-24.1.1
+          - jruby-9.4.12.0
+          - truffleruby-24.1.2
           - system
         os:
           - ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
         exclude:
           # TruffleRuby doesn't work on Windows.
           - os: windows-latest
-            ruby: truffleruby-24.1.1
+            ruby: truffleruby-24.1.2
     defaults:
       run:
         working-directory: examples/gem
@@ -113,7 +113,7 @@ jobs:
       matrix:
         ruby:
           - 3.3.7
-          - jruby-9.4.10.0
+          - jruby-9.4.12.0
     defaults:
       run:
         working-directory: examples/native_ext

--- a/examples/gem/BUILD
+++ b/examples/gem/BUILD
@@ -33,6 +33,7 @@ sh_test(
         ":Rakefile",
         ":rake",
     ],
+    tags = ["bcr-presubmit-failure"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 

--- a/ruby/private/bundler_checksums.bzl
+++ b/ruby/private/bundler_checksums.bzl
@@ -4,6 +4,7 @@
 # curl -sSf https://rubygems.org/api/v1/versions/bundler.json | jq 'map({key: .number, value: .sha}) | from_entries' | grep -vE '\.pre|\.rc|\.beta'
 
 BUNDLER_CHECKSUMS = {
+    "2.6.4": "c4ccca0acc4c3c48e3b8b6335c7ea0e908fb79bab01be1681fdc58ca704eb18c",
     "2.6.3": "29f9386f7b2688b2b4c5e9024058debd91ef88599f33489f62ebcc8898c8c8a3",
     "2.6.2": "4b89756e1b05390ff678491119a10f0973a2045cc9fcb227b02a9396b28f7d74",
     "2.6.1": "b5b86a0ccebbc65390d14d42644f77cdbeef2378469b35273743996be21f5c50",

--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -1,6 +1,6 @@
 "Repository rule for fetching Ruby interpreters"
 
-RUBY_BUILD_VERSION = "20250121"
+RUBY_BUILD_VERSION = "20250215"
 
 _JRUBY_BINARY_URL = "https://repo1.maven.org/maven2/org/jruby/jruby-dist/{version}/jruby-dist-{version}-bin.tar.gz"
 _RUBY_BUILD_URL = "https://github.com/rbenv/ruby-build/archive/refs/tags/v{version}.tar.gz"
@@ -36,6 +36,8 @@ _JRUBY_VERSIONS = {
     "9.4.8.0": "347b6692bd9c91c480a45af25ce88d77be8b6e4ac4a77bc94870f2c5b54bc929",
     "9.4.9.0": "8d64736e66a3c0e1e1ea813b6317219c5d43769e5d06a4417311e2baa8b40ef7",
     "9.4.10.0": "0b325bb6e64896dfcf235bbc6506ca9b5af78f1c8fec7f048bc4188b1793b5e0",
+    "9.4.11.0": "cf4067bdc3a6ab518c786588e2486adc047b9cea0b96a43218b03ac651d26e11",
+    "9.4.12.0": "05c5d203d6990c92671cc42f57d2fa1c1083bbfd16fa7023dc5848cdb8f0aa2e",
 }
 _JRUBY_INTEGRITY_MISSING = """
 


### PR DESCRIPTION
Looks to be an environment issue - the same target works on GitHub Actions CI while fails on Bazel BCR Presubmit.