### PR TITLE
Apply `neverlink = True` to `jars`

### DIFF
--- a/ruby/private/download/BUILD.tpl
+++ b/ruby/private/download/BUILD.tpl
@@ -33,6 +33,7 @@ java_import(
         ["dist/lib/**/*.jar"],
         allow_empty = True,
     ),
+    neverlink = True,
 )
 
 rb_toolchain(


### PR DESCRIPTION
Prevent the implicit inclusion of JRuby's jars into jars made from .java files that have a compile-time dependency on JRuby.

Addresses the root cause of https://github.com/protocolbuffers/protobuf/issues/21369 and will enable the eventual rollback of https://github.com/protocolbuffers/protobuf/pull/21416.