### PR TITLE
test: prepare for bazel 9 built-in rules migration

### DIFF
--- a/examples/gem/.bazelrc
+++ b/examples/gem/.bazelrc
@@ -29,6 +29,9 @@ build --java_runtime_version=remotejdk_21 --tool_java_runtime_version=remotejdk_
 # Not ready for the MODULE.lock file yet, as of Bazel 7.0.0 there are still some stability issues.
 common --lockfile_mode=off
 
+# Prepare for Bazel 9 migration of built-in rules.
+common --incompatible_autoload_externally=
+
 # Ignore timeout different between JRuby and MRI.
 test --test_verbose_timeout_warnings=false
 

--- a/examples/gem/BUILD
+++ b/examples/gem/BUILD
@@ -8,6 +8,7 @@ load(
     "rb_gem_push",
     "rb_test",
 )
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/examples/gem/MODULE.bazel
+++ b/examples/gem/MODULE.bazel
@@ -3,6 +3,8 @@
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "2.11.0", dev_dependency = True)
 bazel_dep(name = "rules_ruby", version = "0.0.0", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
+
 local_path_override(
     module_name = "rules_ruby",
     path = "../..",


### PR DESCRIPTION
This should address BCR failures - https://buildkite.com/bazel/bcr-presubmit/builds/13621#01968f9b-8fea-4416-aa96-61d7f89a8801