### PR TITLE
Fix runfiles merging for `@bazel_tools//tools/bash/runfiles`

### DIFF
--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -56,7 +56,6 @@ Supports `$(location)` expansion for targets from `srcs`, `data` and `deps`.
         default = "@rules_ruby//ruby/private/binary:binary.sh.tpl",
     ),
     "_runfiles_library": attr.label(
-        allow_single_file = True,
         default = "@bazel_tools//tools/bash/runfiles",
     ),
     "_windows_constraint": attr.label(
@@ -141,7 +140,6 @@ def rb_binary_impl(ctx):
     ruby_toolchain = ctx.toolchains["@rules_ruby//ruby:toolchain_type"]
     if ctx.attr.ruby != None:
         ruby_toolchain = ctx.attr.ruby[platform_common.ToolchainInfo]
-    tools = [ctx.file._runfiles_library]
     tools.extend(ruby_toolchain.files)
 
     if ruby_toolchain.version.startswith("jruby"):
@@ -174,6 +172,7 @@ def rb_binary_impl(ctx):
 
     runfiles = ctx.runfiles(tools, transitive_files = depset(transitive = [transitive_srcs, transitive_data]))
     runfiles = get_transitive_runfiles(runfiles, ctx.attr.srcs, ctx.attr.deps, ctx.attr.data)
+    runfiles = runfiles.merge(ctx.attr._runfiles_library[DefaultInfo].default_runfiles)
 
     # Propagate executable from source rb_binary() targets.
     executable = ctx.executable.main

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -140,7 +140,7 @@ def rb_binary_impl(ctx):
     ruby_toolchain = ctx.toolchains["@rules_ruby//ruby:toolchain_type"]
     if ctx.attr.ruby != None:
         ruby_toolchain = ctx.attr.ruby[platform_common.ToolchainInfo]
-    tools.extend(ruby_toolchain.files)
+    tools = ruby_toolchain.files
 
     if ruby_toolchain.version.startswith("jruby"):
         java_toolchain = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"]

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -140,7 +140,7 @@ def rb_binary_impl(ctx):
     ruby_toolchain = ctx.toolchains["@rules_ruby//ruby:toolchain_type"]
     if ctx.attr.ruby != None:
         ruby_toolchain = ctx.attr.ruby[platform_common.ToolchainInfo]
-    tools = ruby_toolchain.files
+    tools = list(ruby_toolchain.files)
 
     if ruby_toolchain.version.startswith("jruby"):
         java_toolchain = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"]

--- a/ruby/private/gem_push.bzl
+++ b/ruby/private/gem_push.bzl
@@ -10,7 +10,7 @@ def _rb_gem_push_impl(ctx):
     if ctx.attr.ruby != None:
         ruby_toolchain = ctx.attr.ruby[platform_common.ToolchainInfo]
     srcs = [ctx.file.gem]
-    tools = [ruby_toolchain.gem, ctx.file._runfiles_library]
+    tools = [ruby_toolchain.gem]
 
     if ruby_toolchain.version.startswith("jruby"):
         env["JAVA_HOME"] = java_toolchain.java_runtime.java_home
@@ -24,6 +24,7 @@ def _rb_gem_push_impl(ctx):
     )
 
     runfiles = ctx.runfiles(srcs + tools)
+    runfiles = runfiles.merge(ctx.attr._runfiles_library[DefaultInfo].default_runfiles)
     env.update(ctx.attr.env)
 
     return [


### PR DESCRIPTION
This is required in Bazel 8.3.0, where this target gained runfiles.