### PR TITLE
chore: fix 0.20.0 release on BCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.15.0
         with:
-          bazelrc: common --announce_rc --color=yes ${{ matrix.mode == 'WORKSPACE' && '--enable_workspace' || '' }}
+          # Move autoload_externally to .bazelrc once Bazel 6 support is dropped.
+          bazelrc: common --announce_rc --color=yes --incompatible_autoload_externally= ${{ matrix.mode == 'WORKSPACE' && '--enable_workspace' || '' }}
           module-root: examples/gem
           # Workaround for long path issues: https://github.com/jruby/jruby/issues/3995.
           output-base: ${{ matrix.os == 'windows-latest' && 'D:/b' || '' }}

--- a/examples/gem/.bazelrc
+++ b/examples/gem/.bazelrc
@@ -29,9 +29,6 @@ build --java_runtime_version=remotejdk_21 --tool_java_runtime_version=remotejdk_
 # Not ready for the MODULE.lock file yet, as of Bazel 7.0.0 there are still some stability issues.
 common --lockfile_mode=off
 
-# Prepare for Bazel 9 migration of built-in rules.
-common --incompatible_autoload_externally=
-
 # Ignore timeout different between JRuby and MRI.
 test --test_verbose_timeout_warnings=false
 

--- a/examples/gem/MODULE.bazel
+++ b/examples/gem/MODULE.bazel
@@ -1,7 +1,7 @@
 "Bazel dependencies"
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "aspect_bazel_lib", version = "2.11.0", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.4", dev_dependency = True)
 bazel_dep(name = "rules_ruby", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 


### PR DESCRIPTION
Fixes CI failures on https://github.com/bazelbuild/bazel-central-registry/pull/5034
See commits for details.