### PR TITLE
fix: exclude external/ from rubocop

### DIFF
--- a/examples/gem/.rubocop.yml
+++ b/examples/gem/.rubocop.yml
@@ -2,6 +2,8 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
   TargetRubyVersion: 3.0
+  Exclude:
+    - 'external/**/*'
 
 # There is a difference in line endings between
 # GitHub Actions and Bazel CI.

--- a/examples/gem/BUILD
+++ b/examples/gem/BUILD
@@ -51,7 +51,10 @@ rb_test(
     name = "rubocop",
     size = "small",
     timeout = "moderate",  # JRuby startup can be slow
-    data = [".rubocop.yml"],
+    data = [
+        ".rubocop.yml",
+        "Gemfile",
+    ],
     main = "@bundle//bin:rubocop",
     tags = ["no-sandbox"],
     deps = [


### PR DESCRIPTION
Fixes BCR failures on 6.x-7.x
https://buildkite.com/bazel/bcr-presubmit/builds/20760/steps/canvas?sid=0199bb51-e4e8-4901-8fad-6abceb9c4dff