### PR TITLE
feat: publish stardocs on releases

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,6 @@
 {
   "integrity": "**leave this alone**",
   "strip_prefix": "{REPO}-{VERSION}",
+  "docs_url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.docs.tar.gz",
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
 }

--- a/rails/BUILD.bazel
+++ b/rails/BUILD.bazel
@@ -10,3 +10,9 @@ bzl_library(
         "//rails/private:rails_test_factory",
     ],
 )
+
+starlark_doc_extract(
+    name = "rails_test_factory.doc_extract",
+    src = "rails_test_factory.bzl",
+    deps = [":rails_test_factory"],
+)

--- a/ruby/BUILD
+++ b/ruby/BUILD
@@ -24,6 +24,12 @@ bzl_library(
     ],
 )
 
+starlark_doc_extract(
+    name = "defs.doc_extract",
+    src = "defs.bzl",
+    deps = [":defs"],
+)
+
 bzl_library(
     name = "deps",
     srcs = ["deps.bzl"],
@@ -32,6 +38,12 @@ bzl_library(
         "//ruby/private:bundle_fetch",
         "//ruby/private:toolchain",
     ],
+)
+
+starlark_doc_extract(
+    name = "deps.doc_extract",
+    src = "deps.bzl",
+    deps = [":deps"],
 )
 
 bzl_library(


### PR DESCRIPTION
They will appear on BCR, similar to https://registry.bazel.build/docs/bazelrc-preset.bzl/1.4.0

You could drop the checked-in stardoc output if you like, to make it easier for casual contributors who get tripped on a red CI status.