### PR TITLE
fix: disable system Ruby on Windows for Gems example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - main
     tags:
       - v*.*.*
+  schedule:
+    - cron: 14 21 * * *
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
## Summary

- Disable system Ruby on Windows test for Gems example.
- Schedule daily CI run to catch errors due to CI env changes.

Related to #282.