### PR TITLE
fix: strip full Java platform suffix from gem version when querying RubyGems API

### DIFF
--- a/ruby/private/bundle_fetch/jars_downloader.bzl
+++ b/ruby/private/bundle_fetch/jars_downloader.bzl
@@ -58,6 +58,34 @@ def _is_java_gem(gem):
     """
     return gem.version.endswith("-java") or "-java-" in gem.version
 
+def _strip_java_platform_suffix(version):
+    """Strips the Java platform suffix from a Ruby gem version string.
+
+    RubyGems joins the platform onto the version with "-", and the Java
+    platform can take several shapes — `java`, `universal-java`, or either
+    of those with a trailing Java version (e.g. `-21`). Examples:
+
+      "5.0.1-java"              -> "5.0.1"
+      "5.0.1-java-8"            -> "5.0.1"
+      "2.6.0-universal-java"    -> "2.6.0"
+      "2.6.0-universal-java-21" -> "2.6.0"
+
+    Args:
+        version: Gem version string, possibly with a Java platform suffix.
+
+    Returns:
+        Version string with the Java platform suffix removed.
+    """
+
+    # Drop any trailing `-N` Java-version segment first ("-java-21" -> "-java").
+    java_idx = version.rfind("-java-")
+    if java_idx >= 0:
+        version = version[:java_idx + len("-java")]
+    for suffix in ("-universal-java", "-java"):
+        if version.endswith(suffix):
+            return version[:-len(suffix)]
+    return version
+
 def _fetch_gem_requirements(repository_ctx, gem):
     """Fetches JAR requirements for a gem from RubyGems API.
 
@@ -72,9 +100,7 @@ def _fetch_gem_requirements(repository_ctx, gem):
         List of JAR requirement strings (e.g., ["jar org.yaml:snakeyaml, 1.33"]).
     """
 
-    # Extract base version without platform suffix
-    # e.g., "psych-5.0.1-java" -> name="psych", version="5.0.1"
-    base_version = gem.version.replace("-java", "")
+    base_version = _strip_java_platform_suffix(gem.version)
 
     url = _RUBYGEMS_API_URL.format(
         gem = gem.name,
@@ -199,4 +225,5 @@ jars_downloader_internal = struct(
     is_java_gem = _is_java_gem,
     parse_jar_requirement = _parse_jar_requirement,
     fetch_gem_requirements = _fetch_gem_requirements,
+    strip_java_platform_suffix = _strip_java_platform_suffix,
 )

--- a/ruby/tests/jars_downloader_tests.bzl
+++ b/ruby/tests/jars_downloader_tests.bzl
@@ -10,7 +10,19 @@ def _is_java_gem_test_impl(ctx):
     env = unittest.begin(ctx)
     asserts.true(env, jars_downloader_internal.is_java_gem(struct(version = "5.0.1-java")))
     asserts.true(env, jars_downloader_internal.is_java_gem(struct(version = "5.0.1-java-8")))
+    asserts.true(env, jars_downloader_internal.is_java_gem(struct(version = "2.6.0-universal-java")))
+    asserts.true(env, jars_downloader_internal.is_java_gem(struct(version = "2.6.0-universal-java-21")))
     asserts.false(env, jars_downloader_internal.is_java_gem(struct(version = "5.0.1")))
+    return unittest.end(env)
+
+def _strip_java_platform_suffix_test_impl(ctx):
+    env = unittest.begin(ctx)
+    strip = jars_downloader_internal.strip_java_platform_suffix
+    asserts.equals(env, "5.0.1", strip("5.0.1-java"))
+    asserts.equals(env, "5.0.1", strip("5.0.1-java-8"))
+    asserts.equals(env, "2.6.0", strip("2.6.0-universal-java"))
+    asserts.equals(env, "2.6.0", strip("2.6.0-universal-java-21"))
+    asserts.equals(env, "5.0.1", strip("5.0.1"))
     return unittest.end(env)
 
 def _parse_jar_requirement_test_impl(ctx):
@@ -40,6 +52,7 @@ def _fetch_gem_requirements_null_test_impl(ctx):
     return unittest.end(env)
 
 is_java_gem_test = unittest.make(_is_java_gem_test_impl)
+strip_java_platform_suffix_test = unittest.make(_strip_java_platform_suffix_test_impl)
 parse_jar_requirement_test = unittest.make(_parse_jar_requirement_test_impl)
 fetch_gem_requirements_null_test = unittest.make(_fetch_gem_requirements_null_test_impl)
 
@@ -47,6 +60,7 @@ def jars_downloader_test_suite():
     unittest.suite(
         "jars_downloader_tests",
         is_java_gem_test,
+        strip_java_platform_suffix_test,
         parse_jar_requirement_test,
         fetch_gem_requirements_null_test,
     )


### PR DESCRIPTION
The previous `gem.version.replace("-java", "")` only handles the bare `-java` platform; for gems whose platform is `universal-java` (e.g. `ffi-yajl-2.6.0-universal-java`) it leaves a `-universal` tail and queries a non-existent RubyGems version, hard-failing the repo rule.

Replace the naive strip with a helper that covers all four real-world Java platform shapes: `java`, `java-N`, `universal-java`, `universal-java-N`.