### PR TITLE
docs: fix broken README link in rb_test docstring for Bazel registry

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -655,7 +655,7 @@ bazel coverage //...
 > [!NOTE]
 > Code coverage is currently not supported on Windows.
 
-See the [README](../../README.md#code-coverage) for more details.
+See the [README](https://github.com/bazel-contrib/rules_ruby/blob/main/README.md#code-coverage) for more details.
 
 Note that you can also `run` every test target passing extra arguments to
 the Ruby script. For example, you can re-use `:rubocop` target to perform autocorrect:

--- a/ruby/private/test.bzl
+++ b/ruby/private/test.bzl
@@ -128,7 +128,7 @@ bazel coverage //...
 > [!NOTE]
 > Code coverage is currently not supported on Windows.
 
-See the [README](../../README.md#code-coverage) for more details.
+See the [README](https://github.com/bazel-contrib/rules_ruby/blob/main/README.md#code-coverage) for more details.
 
 Note that you can also `run` every test target passing extra arguments to
 the Ruby script. For example, you can re-use `:rubocop` target to perform autocorrect:


### PR DESCRIPTION
## Summary
- The `rb_test` docstring links to `../../README.md#code-coverage`, which is a relative file path that works on GitHub but breaks on the Bazel registry ([registry.bazel.build](https://registry.bazel.build)), where it resolves to a 404.
- Replaced with an absolute GitHub URL so the link works on both GitHub and the registry.

You can see the broken link here: https://registry.bazel.build/docs/rules_ruby (in the `rb_test` > Code Coverage section)

## Test plan
Manual testing:
1. Visit https://registry.bazel.build/docs/rules_ruby
2. Find the `rb_test` rule documentation, scroll to the "Code Coverage" section
3. Click the "README" link — currently leads to a 404
4. After this fix, the link will point to https://github.com/bazel-contrib/rules_ruby/blob/main/README.md#code-coverage