### PR TITLE
fix: emit Windows batch launchers with CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # In code review, collapse generated files
 docs/*.md linguist-generated=true
+
+# cmd.exe finds batch labels by byte offset and fails on LF-only .cmd files,
+# so these launcher templates must stay CRLF.
+ruby/private/**/*.cmd.tpl text eol=crlf

--- a/ruby/private/utils.bzl
+++ b/ruby/private/utils.bzl
@@ -14,6 +14,7 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 """
 
 # https://github.com/aspect-build/bazel-lib/blob/ddac9c46c3bff4cf8d0118a164c75390dbec2da9/lib/windows_utils.bzl
+# Normalized to CRLF; cmd.exe can't reliably find batch labels in LF-only .cmd files.
 BATCH_RLOCATION_FUNCTION = r"""
 rem Usage of rlocation function:
 rem        call :rlocation <runfile_path> <abs_path>
@@ -76,7 +77,7 @@ set %~2=!abs_path!
 exit /b 0
 :rlocation_end
 :: End of rlocation
-"""
+""".replace("\r\n", "\n").replace("\n", "\r\n")
 
 def is_windows(ctx):
     windows_constraint = ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]
@@ -95,14 +96,16 @@ def convert_env_to_script(ctx, env):
     environment = []
     if is_windows(ctx):
         export_command = "set"
+        newline = "\r\n"  # keep the generated .cmd CRLF; see BATCH_RLOCATION_FUNCTION
     else:
         export_command = "export"
+        newline = "\n"
 
     for (name, value) in env.items():
         command = "{command} {name}={value}".format(command = export_command, name = name, value = value)
         environment.append(command)
 
-    return "\n".join(environment)
+    return newline.join(environment)
 
 def normalize_path(ctx, path):
     """Converts path to an OS-specific equivalent.


### PR DESCRIPTION
## Problem

- On Windows, `rb_binary`/`rb_test` intermittently failed with `The system cannot find the batch label specified - rlocation`, breaking runfiles lookups (`rlocation`, `require 'bazel/runfiles'`). Linux and macOS were unaffected.
- Root cause is line endings, not batch logic: the generated `.cmd` launcher is LF-only, and `cmd.exe` seeks `goto`/`call :label` targets by byte offset — a scan that is unreliable on LF-only files. Failures were non-deterministic (whether a label straddled an internal read-buffer boundary), which is the signature of this bug rather than a code error.

## Solution

- Emit the generated `.cmd` with CRLF throughout. It's assembled from two pieces, so both are handled: the `*.cmd.tpl` templates are pinned to CRLF via `.gitattributes`, and the batch code injected from Starlark is normalized to CRLF.
- The `.gitattributes` pin isn't dev-only. The same CRLF conversion is applied when the release archive is built, so consumers get the fixed launchers whether they depend on rules_ruby via BCR, an archive, or git.

## Receipts

Downstream Selenium Windows CI, same target set, with an override onto this branch ([SeleniumHQ/selenium@9e400e6](https://github.com/SeleniumHQ/selenium/commit/9e400e659ef5406f466f673b3a8baeda449b8d84)):

- Before: [22/51 `rb_test` targets fail](https://github.com/SeleniumHQ/selenium/actions/runs/30910539187) at `require 'bazel/runfiles'` (non-deterministic across identical targets on one machine).
- After: [all green](https://github.com/SeleniumHQ/selenium/actions/runs/30952822410/job/92138819167).
